### PR TITLE
fix setup.py in Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(name=app.NAME,
           'Operating System :: OS Independent',
           'Programming Language :: Python',
           'Intended Audience :: Developers'],
-      long_description=codecs.open('README.rst').read()
+      long_description=codecs.open('README.rst', 'r').read()
       )


### PR DESCRIPTION
The installation doesn't work in Python 3.4. This patch fixes it.