### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip install tox "coverage<4.0" python-coveralls>=2.5 coveralls>=0.5 codecov
 
 script:
-  - tox -e $TOXENV -- py.test tests -v --capture=no \
+  - tox -e $TOXENV -- py.test tests -v --capture=no
       --cov=adminfilters --cov-report=xml --cov-config=tests/.coveragerc
 
 before_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ python:
   - 3.5
 
 env:
- - TOXENV=py26-d14
- - TOXENV=py26-d15
- - TOXENV=py26-d16
-
- - TOXENV=py27-d14
- - TOXENV=py27-d15
- - TOXENV=py27-d16
  - TOXENV=py27-d17
  - TOXENV=py27-d18
  - TOXENV=py27-d19


### PR DESCRIPTION
I am fixing Travis tests by fixing it's configuration and removing versions that are not supported by `pytest-django` anymore.

Please, create PyPI package after merging this package. There are few very useful fixes in the develop branch now.