### PR TITLE
Fixed #36

### DIFF
--- a/src/adminfilters/autocomplete.py
+++ b/src/adminfilters/autocomplete.py
@@ -29,8 +29,8 @@ class AutoCompleteFilter(SmartFieldListFilter, MediaDefinitionFilter):
         self.lookup_kwarg_isnull = "%s__isnull" % field_path
         self._params = params
         self.request = request
-        super().__init__(field, request, params, model, model_admin, field_path)
         self.lookup_val = self.get_parameters(self.lookup_kwarg)
+        super().__init__(field, request, params, model, model_admin, field_path)
         self.admin_site = model_admin.admin_site
         self.query_string = ""
         self.target_field = get_real_field(model, field_path)

--- a/tests/functional/test_f_automplete.py
+++ b/tests/functional/test_f_automplete.py
@@ -25,3 +25,5 @@ def test_autocomplete(admin_site):
     admin_site.wait_and_click(By.XPATH, '//li[contains(text(), "United Kingdom")]')
     *__, cl = get_elements(admin_site.driver)
     assert set(cl.get_values(None, 5)) == {"United Kingdom"}
+    el = admin_site.driver.find_elements(By.ID, "select2-ac_country-container")
+    assert 'United Kingdom' in el[0].text


### PR DESCRIPTION
in adminfilters.autocomplete.AutoCompleteFilter.__init__
the _get_parameters_ must be executed before the super().__init__